### PR TITLE
Bump go version to fix runtime vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DOCKER_TMP_CONTAINER_NAME = trainbot-tmp-container
 # https://hub.docker.com/_/debian
 DOCKER_BASE_IMAGE = debian:bullseye-20230522
 # https://go.dev/dl/
-GO_VERSION = 1.20.4
-GO_ARCHIVE_SHA256 = 698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd
+GO_VERSION = 1.20.5
+GO_ARCHIVE_SHA256 = d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612
 # https://github.com/dominikh/go-tools/releases
 GO_STATICCHECK_VERSION = 2023.1.3
 


### PR DESCRIPTION
Vulnerability: GO-2023-1840
More info: https://pkg.go.dev/vuln/GO-2023-1840

Standard library
  Found in: runtime@go1.20.4
  Fixed in: runtime@go1.20.5