### PR TITLE
Fix blobs with timestamp seconds fragment of .000 not loading

### DIFF
--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -5,10 +5,10 @@ const blobsBaseURL = import.meta.env.VITE_BLOBS_URL
 // This matches time.Format() with '20060102_150405.999_Z07:00' from Go.
 function formatFileTs(ts: DateTime): string {
   const base = ts.toFormat('yyyyMMdd_HHmmss')
-  const frac = ts.toFormat('SSS').replace(/0*$/, '')
+  const frac = ts.toFormat('.SSS').replace(/\.?0*$/, '')
   const zone = ts.toFormat('ZZ').replace('+00:00', 'Z')
 
-  return `${base}.${frac}_${zone}`
+  return `${base}${frac}_${zone}`
 }
 
 export function imgFileName(ts: DateTime): string {


### PR DESCRIPTION
here is an example of the bug: https://trains.jo-m.ch/#/trains/75159